### PR TITLE
Update excel.rb to export as worksheet

### DIFF
--- a/lib/make_exportable/exportable_formats/excel.rb
+++ b/lib/make_exportable/exportable_formats/excel.rb
@@ -7,6 +7,7 @@ module MakeExportable #:nodoc:
     
     attr_accessor :data_set, :data_headers
     
+
     def initialize(data_set, data_headers=[])
       self.long      = 'Microsoft Excel'
       self.mime_type = 'application/vnd.ms-excel; charset=utf-8;'
@@ -16,18 +17,31 @@ module MakeExportable #:nodoc:
 
     def generate
       generate_header_option(data_headers)
-      output = "<table>\n"
+      output = "<?xml version='1.0'?>\n"
+      output << "<Workbook xmlns='urn:schemas-microsoft-com:office:spreadsheet'\n"
+      output << "\txmlns:o='urn:schemas-microsoft-com:office:office'\n"
+      output << "\txmlns:x='urn:schemas-microsoft-com:office:excel'\n"
+      output << "\txmlns:ss='urn:schemas-microsoft-com:office:spreadsheet'\n"
+      output << "\txmlns:html='http://www.w3.org/TR/REC-html40'>\n"
+      output << "\t<Worksheet ss:Name='Sheet1'>\n"
+      output << "\t\t<Table>\n"
+
       unless data_headers.blank?
-        output << "\t<tr>\n"
-        output << data_headers.map {|h| "\t\t<th>#{sanitize(h.humanize.titleize)}</th>\n" }.join
-        output << "\t</tr>\n"
+        output << "\t\t\t<Row>\n"
+        output << data_headers.map {|h| "\t\t\t\t<Cell><Data ss:Type='String'>#{sanitize(h.humanize.titleize)}</Data></Cell>\n" }.join
+        output << "\t\t\t</Row>\n"
       end
+
       data_set.each do |row|
-        output << "\t<tr>\n"
-        output << row.map {|field| "\t\t<td>#{sanitize(field)}</td>\n"}.join
-        output << "\t</tr>\n"
+        output << "\t\t\t<Row>\n"
+        output << row.map {|field| "\t\t\t\t<Cell><Data ss:Type='String'>#{sanitize(field)}</Data></Cell>\n" }.join
+        output << "\t\t\t</Row>\n"
       end
-      output << "</table>\n"
+
+      output << "\t\t</Table>\n"
+      output << "\t</Worksheet>\n"
+      output << "</Workbook>\n"
+
       return output
     end
 


### PR DESCRIPTION
Later versions of office are producing this error when trying to open .xls files created by make_exportable:

```
The file format and extension of 'file.xls' don't match. The file could be corrupted or unsafe. Unless you trust its source, don't open it. Do you want to open it anyway?
```

This patch makes the xls export produce correct files that do not produce this warning.